### PR TITLE
Fix for issue #19

### DIFF
--- a/smoke_test.sh
+++ b/smoke_test.sh
@@ -71,5 +71,6 @@ fi
 
 echo_run $BINPATH -t ./binspector/test/issue1.bfft -i ./binspector/test/empty.bin -m validate
 echo_run $BINPATH -t ./binspector/test/issue11.bfft -i $JPEGPATH -m validate
+echo_run $BINPATH -t ./binspector/test/issue19.bfft -i ./binspector/test/empty.bin -m validate
 echo_run $BINPATH -t ./binspector/bfft/png.bfft -i $PNGPATH -m validate
 echo_run $BINPATH -t ./binspector/bfft/jpg.bfft -i $JPEGPATH -m validate

--- a/source/analyzer.cpp
+++ b/source/analyzer.cpp
@@ -168,8 +168,14 @@ void binspector_analyzer_t::add_named_field(adobe::name_t              name,
         return;
 
     structure_type& current_structure(*current_structure_m);
+    adobe::name_t   type(value_for<adobe::name_t>(parameters, key_field_type));
 
-    check_duplicate_field_name(current_structure, name);
+    // Signals are declarations that don't produce a field, so the fact there
+    // could be a field with the same name as the signal is ok. (We may want to
+    // consider doing something similar for invariant names, too, to relax the
+    // restriction that their names be unique.)
+    if (type != value_field_type_signal)
+        check_duplicate_field_name(current_structure, name);
 
     current_structure.push_back(adobe::any_regular_t(parameters));
 }

--- a/test/issue19.bfft
+++ b/test/issue19.bfft
@@ -1,0 +1,7 @@
+struct main
+{
+    // Issue #19 : Signals should be declarable in the same structure as their associated slot.
+    slot done = false;
+
+    signal done = true;
+}


### PR DESCRIPTION
the name of the signal field is not checked to see if it is a duplicate, as it does not create a node in the final parse tree.
